### PR TITLE
feat: bump pgbouncer version to 1.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.7
-ARG VERSION=1.9.0
+ARG VERSION=1.11.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 RUN \


### PR DESCRIPTION
Bump pgbouncer version to 1.11.0 for latest dockerfile.
It has been tested and it includes new features useful to have