### PR TITLE
Stop encrypting passwords with plain auth type

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,8 +40,12 @@ fi
 # Write the password with MD5 encryption, to avoid printing it during startup.
 # Notice that `docker inspect` will show unencrypted env variables.
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" ] && ! grep -q "^\"$DB_USER\"" ${PG_CONFIG_DIR}/userlist.txt; then
-  encrypted_pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"
-  echo "\"$DB_USER\" \"$encrypted_pass\"" >> ${PG_CONFIG_DIR}/userlist.txt
+  if [ "$AUTH_TYPE" != "plain" ]; then
+     pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"
+  else
+     pass="$DB_PASSWORD"
+  fi
+  echo "\"$DB_USER\" \"$pass\"" >> ${PG_CONFIG_DIR}/userlist.txt
   echo "Wrote authentication credentials to ${PG_CONFIG_DIR}/userlist.txt"
 fi
 


### PR DESCRIPTION
Hi, current implementation does not really support plain mode, as passwords are unconditionally md5 hashed. This small patch fixes that.