### PR TITLE
adds AUTH_USER env var creation of auth_user ini param

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,7 @@ user = postgres
 auth_file = ${AUTH_FILE:-$PG_CONFIG_DIR/userlist.txt}
 ${AUTH_HBA_FILE:+auth_hba_file = ${AUTH_HBA_FILE}\n}\
 auth_type = ${AUTH_TYPE:-md5}
+${AUTH_USER:+auth_user = ${AUTH_USER}\n}\
 ${AUTH_QUERY:+auth_query = ${AUTH_QUERY}\n}\
 ${POOL_MODE:+pool_mode = ${POOL_MODE}\n}\
 ${MAX_CLIENT_CONN:+max_client_conn = ${MAX_CLIENT_CONN}\n}\


### PR DESCRIPTION
First, thanks for putting this container together, it's the highest quality pgbouncer build I've been able to find!

We use auth_user in our ini file as in this article:

https://www.cybertec-postgresql.com/en/pgbouncer-authentication-made-easy/

and would love to be able to do that using this build without forking or extending it.

This adds the ability to create that param in the same fashion as all the other optional ini params.
