### PR TITLE
Fix generate-userlist script

### DIFF
--- a/examples/generate-userlist
+++ b/examples/generate-userlist
@@ -1,21 +1,21 @@
-#!/bin/sh
+#!/bin/bash
 # A single script to generate an entry in for userlist.txt
 # Usage:
 #
 # ./generate-userlist >> userlist.txt
-# ./generate-userlist usernaem >> userlist.txt
+# ./generate-userlist username >> userlist.txt
 #
 
 if [[ $# -eq 1 ]]; then
   USERNAME="$1"
 else
-  read -p "Enter username: " USERNAME
+  read -r -p "Enter username: " USERNAME
 fi
 
-read -s -p "Enter password: " PASSWORD
+read -r -s -p "Enter password: " PASSWORD
 echo >&2
 
 # Using openssl md5 to avoid differences between OSX and Linux (`md5` vs `md5sum`)
-encrypted_password="md5$(printf "$PASSWORD$USERNAME" | openssl md5)"
+encrypted_password="md5$(printf "%s%s" "$PASSWORD" "$USERNAME" | openssl md5 -binary | xxd -p)"
 
 echo "\"$USERNAME\" \"$encrypted_password\""


### PR DESCRIPTION
Hello there.

I'm writing this PR, because as of this moment, with `openssl 1.1.1.d-2`, the `generate-userlist` script does not produce the right output file.

The issue can be fairly easy replicated by running `echo md5$(printf "PasswordUser" | openssl md5)` which wrongly outputs `md5(stdin)= d4872d25d13669e4f3106a8972f09d26`. 

To those familiar with the previous file format, you might be wondering wth is that `(stdin)= ` doing there. That's a change in openssl output. A solution can be found here: https://unix.stackexchange.com/a/90242 . The `xxd` binary is widely available, so I think it should not be an issue.

I've also taken the liberty to lint the script according to `shellcheck`.

Lmk what do you think.