### PR TITLE
Allow computation of stats without logging (log_stats configuration option support)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,6 +89,7 @@ ${APPLICATION_NAME_ADD_HOST:+application_name_add_host = ${APPLICATION_NAME_ADD_
 ${LOG_CONNECTIONS:+log_connections = ${LOG_CONNECTIONS}\n}\
 ${LOG_DISCONNECTIONS:+log_disconnections = ${LOG_DISCONNECTIONS}\n}\
 ${LOG_POOLER_ERRORS:+log_pooler_errors = ${LOG_POOLER_ERRORS}\n}\
+${LOG_STATS:+log_stats = ${LOG_STATS}\n}\
 ${STATS_PERIOD:+stats_period = ${STATS_PERIOD}\n}\
 ${VERBOSE:+verbose = ${VERBOSE}\n}\
 admin_users = ${ADMIN_USERS:-postgres}


### PR DESCRIPTION
As of pgbouncer 1.11.0, there is a [`log_stats` configuration option](https://github.com/pgbouncer/pgbouncer/pull/287) that allows stats to be computed for consumption by an external tool every `stats_period`, but allows the user to prevent this re-calculation of stats from being logged to the logfile or stdout.

This PR adds support for this configuration for use cases where external monitoring is used to track pgbouncer performance and local logging is undesirable.