### PR TITLE
Touch userlist File if it Doesn't Exist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,13 @@ fi
 # Write the password with MD5 encryption, to avoid printing it during startup.
 # Notice that `docker inspect` will show unencrypted env variables.
 _AUTH_FILE="${AUTH_FILE:-$PG_CONFIG_DIR/userlist.txt}"
+
+# Workaround userlist.txt missing issue
+# https://github.com/edoburu/docker-pgbouncer/issues/33
+if [ ! -e "${_AUTH_FILE}" ]; then
+  touch "${_AUTH_FILE}"
+fi
+
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
   if [ "$AUTH_TYPE" != "plain" ]; then
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"


### PR DESCRIPTION
Create /etc/pgbouncer/userlist.txt (or alternatively placed file) if it doesn't exist by default. This file was apparently removed from upstream around the end of 2020, beginning of 2021.

By creating the file before attempting to grep it for the existing user, grep should work and since it's wrapped in a test block if end users supply their own (through volume mounts or otherwise) it shouldn't change the date on the file.