### PR TITLE
Add Admin and Stats Users to userlist

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,6 +40,13 @@ fi
 # Write the password with MD5 encryption, to avoid printing it during startup.
 # Notice that `docker inspect` will show unencrypted env variables.
 _AUTH_FILE="${AUTH_FILE:-$PG_CONFIG_DIR/userlist.txt}"
+
+# Workaround userlist.txt missing issue
+# https://github.com/edoburu/docker-pgbouncer/issues/33
+if [ ! -e "${_AUTH_FILE}" ]; then
+  touch "${_AUTH_FILE}"
+fi
+
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
   if [ "$AUTH_TYPE" != "plain" ]; then
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"


### PR DESCRIPTION
In conjunction with the last PR creating the userlist if it doesn't already exist, also add in ADMIN_USERS and STATS_USERS if cooresponding ADMIN_PASSWORDS and STATS_PASSWORDS ENV variables are provided.

This is more of an out there PR and you can feel free to throw it out if you dislike it but I think it would make management easier.

For example with the following ENV variables

ADMIN_USERS=postgres,pg
ADMIN_PASSWORDS=postgres,pg
STATS_USERS=stats
STATS_PASSWORDS=stats

It produces STDOUT

Wrote postgres (admin) authentication credentials to /etc/pgbouncer/userlist.txt
Wrote pg (admin) authentication credentials to /etc/pgbouncer/userlist.txt
Wrote stats (stats) authentication credentials to /etc/pgbouncer/userlist.txt

and writes the following MD5 hashes into the userlist.txt

"postgres" "md53175bce1d3201d16594cebf9d7eb3f9d"
"pg" "md5971658c8903b1b9727ce2bc9081d71b0"
"stats" "md5a57ebe01934de43865125819a3c4af74"

This PR includes both the original PR as well as the new stuff for admin and stats users since you can't really run this new code without the touch fix.