### PR TITLE
Add timezone option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -92,6 +92,7 @@ ${SERVER_ROUND_ROBIN:+server_round_robin = ${SERVER_ROUND_ROBIN}\n}\
 ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits}
 ${DISABLE_PQEXEC:+disable_pqexec = ${DISABLE_PQEXEC}\n}\
 ${APPLICATION_NAME_ADD_HOST:+application_name_add_host = ${APPLICATION_NAME_ADD_HOST}\n}\
+${TIMEZONE:+timezone = ${TIMEZONE}\n}\
 
 # Log settings
 ${LOG_CONNECTIONS:+log_connections = ${LOG_CONNECTIONS}\n}\


### PR DESCRIPTION
This adds support for the `TIMEZONE` env var, which corresponds to the [timezone pgbouncer option](https://www.pgbouncer.org/config.html#timezone).