### PR TITLE
[entrypoint] support scram-sha-256

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Based on https://raw.githubusercontent.com/brainsam/pgbouncer/master/entrypoint.sh
 
 set -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,10 +48,10 @@ if [ ! -e "${_AUTH_FILE}" ]; then
 fi
 
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
-  if [ "$AUTH_TYPE" != "plain" ]; then
-     pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"
-  else
+  if ["$AUTH_TYPE" == "plain" || "$AUTH_TYPE" == "scram-sha-256"]; then
      pass="$DB_PASSWORD"
+  else
+     pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"
   fi
   echo "\"$DB_USER\" \"$pass\"" >> ${PG_CONFIG_DIR}/userlist.txt
   echo "Wrote authentication credentials to ${PG_CONFIG_DIR}/userlist.txt"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Based on https://raw.githubusercontent.com/brainsam/pgbouncer/master/entrypoint.sh
 
 set -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ if [ ! -e "${_AUTH_FILE}" ]; then
 fi
 
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
-  if [ "$AUTH_TYPE" == "plain" || "$AUTH_TYPE" == "scram-sha-256" ]; then
+  if [ "$AUTH_TYPE" == "plain" ] || [ "$AUTH_TYPE" == "scram-sha-256" ]; then
      pass="$DB_PASSWORD"
   else
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ if [ ! -e "${_AUTH_FILE}" ]; then
 fi
 
 if [ -n "$DB_USER" -a -n "$DB_PASSWORD" -a -e "${_AUTH_FILE}" ] && ! grep -q "^\"$DB_USER\"" "${_AUTH_FILE}"; then
-  if ["$AUTH_TYPE" == "plain" || "$AUTH_TYPE" == "scram-sha-256"]; then
+  if [ "$AUTH_TYPE" == "plain" || "$AUTH_TYPE" == "scram-sha-256" ]; then
      pass="$DB_PASSWORD"
   else
      pass="md5$(echo -n "$DB_PASSWORD$DB_USER" | md5sum | cut -f 1 -d ' ')"


### PR DESCRIPTION
Modifies the entrypoint to allow for `scram-sha-256` password encryption with plaintext password in the `userlist.txt` file.

According to the [pgbouncer.ini params page](https://www.pgbouncer.org/config.html), if auth_type is SCRAM-SHA-256, then the auth_file must contain SCRAM secrets or plain-text passwords. This PR makes it such that if auth_type is set to scram-sha-256, the `userlist.txt` file is written by default with a plaintext password rather than with `md5` encryption