### PR TITLE
[entrypoint] validate connection str and escape special chars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,10 +41,10 @@ if [ -n "$DATABASE_URL" ]; then
   hostport=`echo $url | sed -e s,$userpass_esc@,,g | cut -d/ -f1`
   port=`echo $hostport | grep : | cut -d: -f2`
   if [ -n "$port" ]; then
-    DB_HOST=`echo $hostport | grep : | cut -d: -f1`
-    DB_PORT=$port
+      DB_HOST=`echo $hostport | grep : | cut -d: -f1`
+      DB_PORT=$port
   else
-    DB_HOST=$hostport
+      DB_HOST=$hostport
   fi
 
   DB_NAME="$(echo $url | grep / | cut -d/ -f2-)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,12 +11,9 @@ PG_CONFIG_DIR=/etc/pgbouncer
 if [ -n "$DATABASE_URL" ]; then
   # Thanks to https://stackoverflow.com/a/17287984/146289
 
-  # Check that begins with valid postgres:// prefix and has at max one '@' char
+  # Check that connection string has at max one '@' char
   charcount=$(echo $DATABASE_URL | grep -o "@" | wc -l)
-  if [[ ! "$DATABASE_URL" =~ ^postgres:// ]]; then
-    echo 1>&2 "$0: invalid postgres connection string"
-    exit 2
-  elif [ $charcount -gt 1 ]; then
+  if [ $charcount -gt 1 ]; then
     echo 1>&2 "$0: invalid multiple '@' chars in connection string"
     exit 2
   fi


### PR DESCRIPTION
Checks that connection string begins with a valid `postgres://` and contains at max one `@` character.

Escapes `*` and `.` special chars when parsing the hostport from the connection string.