### PR TITLE
chore: bump 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.17
-ARG VERSION=1.18.0
+ARG VERSION=1.19.1
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018


### PR DESCRIPTION
fix: Fail hard during startup when none of the addresses in listen_addr could be listened on. (https://github.com/pgbouncer/pgbouncer/pull/838)