### PR TITLE
Update pgbouncer to version 1.22.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.18
-ARG VERSION=1.22.0
+ARG VERSION=1.22.1
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018


### PR DESCRIPTION
This PR updates pgbouncer to version `1.22.1`.
Coming from `1.22.0` this is only a minor upgrade.

Changelog from pgbouncer:
> Fixes
>   - Fix issues caused by some clients using COPY FROM STDIN queries. Such queries could introduce memory leaks, performance regressions and prepared statement misbehavior. ([https://github.com/pgbouncer/pgbouncer/pull/1025]) (bug introduced in 1.21.0)
>   - Add missing tests to release tarball ([https://github.com/pgbouncer/pgbouncer/pull/1026]) (missing tests were introduced in 1.19.0 & 1.21.0)
