### PR TITLE
feat: Use tini as entrypoint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/examples/docker-compose"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/examples/kubernetes/multiuser"
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: "/examples/kubernetes/singleuser"
+  schedule:
+    interval: weekly

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Features:
 * Includes PostgreSQL client tools such as ``psql``, ``pg_isready``
 * MD5 authentication by default.
 * `/etc/pgbouncer/pgbouncer.ini` and `/etc/pbbouncer/userlist.txt` are auto-created if they don't exist.
+* Uses [tini](https://github.com/krallin/tini) as entrypoint to respect default signal handlers.
 
 Why use PgBouncer
 -----------------

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   db:
     image: postgres:16-alpine
+    init: true
     volumes:
       - pg_data:/var/lib/postgresql/data
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d


### PR DESCRIPTION
### Updates
* Alpine 3.20 (fixes 5 security findings)
* Let Dependabot update images in Dockerfile, docker-compose.yml and Kubernetes manifests

### Improvements
* Use tini as entrypoint for Dockerfile and docker-compose.yml example

### Transfer size (compressed image) should be
* amd64 = 7.1 MB
* arm64 = 7.6 MB
* multi = 14.7 MB