### PR TITLE
Update pgbouncer to version 1.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.18
-ARG VERSION=1.22.1
+ARG VERSION=1.23.0
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018


### PR DESCRIPTION
A new version was released on Jul 3, 2024:
https://www.pgbouncer.org/2024/07/pgbouncer-1-23-0