### PR TITLE
Bump pgbouncer to 1.24.1

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        pgbouncer_version: ["1.20.1", "1.21.0", "1.22.1", "1.23.1"]
+        pgbouncer_version: ["1.20.1", "1.21.0", "1.22.1", "1.23.1", "1.24.1"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.21 AS build
-ARG VERSION=1.24.0
+ARG VERSION=1.24.1
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-IMAGE_NAME=edoburu/pgbouncer
-IMAGE_VERSION=latest
+IMAGE_NAME?=edoburu/pgbouncer
+IMAGE_VERSION?=latest
 
 docker-x86:
 	docker buildx build \

--- a/examples/docker-compose-trust/docker-compose.yml
+++ b/examples/docker-compose-trust/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     build:
       context: ../..
       args:
-        VERSION: 1.22.1
+        VERSION: 1.24.1
     ### download from dockerhub
     # image: edoburu/pgbouncer:latest
     restart: always

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build:
       context: ../..
       # args:
-      #   VERSION: 1.23.0
+      #   VERSION: 1.24.1
     ### download from dockerhub
     # image: edoburu/pgbouncer:latest
     environment:


### PR DESCRIPTION
Relase notes for 1.24.1: https://github.com/pgbouncer/pgbouncer/releases/tag/pgbouncer_1_24_1

And I wanted to be able to run `IMAGE_NAME=me/myimage IMAGE_VERSION=1.2.3 make push`, so I changed the Makefile accordingly.