### PR TITLE
Make `user` directive optional

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,7 +114,7 @@ if [ ! -f "${PG_CONFIG_FILE}" ]; then
 listen_addr = ${LISTEN_ADDR:-0.0.0.0}
 listen_port = ${LISTEN_PORT:-5432}
 unix_socket_dir = ${UNIX_SOCKET_DIR}
-user = postgres
+${USER:+user = ${USER}\n}\
 auth_file = ${_AUTH_FILE}
 ${AUTH_HBA_FILE:+auth_hba_file = ${AUTH_HBA_FILE}\n}\
 auth_type = ${AUTH_TYPE:-md5}


### PR DESCRIPTION
The default for the `user` directive in pgBouncer is "not present".
Using it creates problems running this container in Kubernetes/OpenShift with securityContexts given.
Making it optional allows using a UID that's not postgres or root.

Also, I filtered the entrypoint script through shellcheck, applied autofixes, and manually applied the POSIX compatibility recommendations.