### PR TITLE
Apply Alpine security upgrades at image build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ ARG VERSION=1.25.1
 
 # Inspiration from https://github.com/gmr/alpine-pgbouncer/blob/master/Dockerfile
 # hadolint ignore=DL3003,DL3018
-RUN apk add --no-cache autoconf automake curl gcc libc-dev libevent-dev libtool make openssl-dev pkgconfig
+RUN apk add --no-cache autoconf automake curl gcc libc-dev libevent-dev libtool make openssl-dev pkgconfig && \
+  apk upgrade --no-cache
 
 # build version for release
 RUN curl -sS -o /pgbouncer.tar.gz -L https://pgbouncer.github.io/downloads/files/$VERSION/pgbouncer-$VERSION.tar.gz && \
@@ -13,7 +14,7 @@ RUN cd /pgbouncer && ./configure --prefix=/usr && make -j$(nproc) pgbouncer && s
 
 FROM alpine:3.22
 
-RUN apk add --no-cache libevent postgresql-client && \
+RUN apk add --no-cache libevent postgresql-client && apk upgrade --no-cache && \
   mkdir -p /etc/pgbouncer /var/log/pgbouncer /var/run/pgbouncer && \
   touch /etc/pgbouncer/userlist.txt && \
   chown -R postgres /var/log/pgbouncer /var/run/pgbouncer /etc/pgbouncer


### PR DESCRIPTION
## Summary

Lacework (`lw-scanner`) reported **6 fixable CVEs** on `edoburu/pgbouncer:latest` (all from Alpine 3.22 base packages):

| CVE | Severity | Package | Fix version |
|-----|----------|---------|-------------|
| CVE-2026-40200 | High | musl | 1.2.5-r12 |
| CVE-2026-6042 | Low | musl | 1.2.5-r11 |
| CVE-2025-60876 | Medium | busybox | 1.37.0-r20 |
| CVE-2026-27171 | Medium | zlib | 1.3.2-r0 |
| CVE-2024-58251 | Low | busybox | 1.37.0-r20 |
| CVE-2025-46394 | Low | busybox | 1.37.0-r20 |

Published `latest` still ships older packages (`musl-1.2.5-r10`, `busybox-1.37.0-r19`, `zlib-1.3.1-r2`) from the Dec 2025 build.

This PR runs `apk upgrade --no-cache` in both Dockerfile stages after `apk add`, so rebuilds always pull current Alpine security fixes even when the `alpine:3.22` base layer is cached.

## Verification

```bash
docker build -t docker-pgbouncer:fixed .
~/lacework/lw-scanner image evaluate docker-pgbouncer fixed --no-pull -v
# → Good news! This image has no vulnerabilities.
```

## Test plan

- [x] Build image locally
- [x] `lw-scanner image evaluate` reports zero vulnerabilities
- [ ] CI / multi-arch publish (if applicable)

Made with [Cursor](https://cursor.com)