### PR TITLE
fix: let AUTH_USER apply when DB_USER does not name one

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ examples/generate-userlist >> userlist.txt
 You can also connect with a single user to PgBouncer, and from there retrieve the actual database password
 by setting ``AUTH_USER``. See the example from: <https://www.cybertec-postgresql.com/en/pgbouncer-authentication-made-easy/>
 
+The generated database entry uses ``DB_USER`` as its ``auth_user`` when that is set, ``AUTH_USER`` otherwise,
+and falls back to ``postgres``.
+
 Connecting to the admin console
 -------------------------------
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,7 +67,7 @@ function generate_userlist_if_needed() {
 function generate_config_db_entry() {
   printf "\
 ${DB_NAME:-*} = host=${DB_HOST:?"Setup pgbouncer config error! You must set DB_HOST env"} \
-port=${DB_PORT:-5432} auth_user=${DB_USER:-postgres}
+port=${DB_PORT:-5432} auth_user=${DB_USER:-${AUTH_USER:-postgres}}
 ${CLIENT_ENCODING:+client_encoding = ${CLIENT_ENCODING}\n}\
 " >> "${PG_CONFIG_FILE}"
 }


### PR DESCRIPTION
Fixes #134.

- `AUTH_USER` sets `auth_user` in the `[pgbouncer]` section, pgbouncer's default for databases naming none of their own.
- `generate_config_db_entry` always writes a per-database `auth_user`, and the per-database value wins.
- So `AUTH_USER` never reaches a generated entry.

```diff
-port=${DB_PORT:-5432} auth_user=${DB_USER:-postgres}
+port=${DB_PORT:-5432} auth_user=${DB_USER:-${AUTH_USER:-postgres}}
```

### Reproducing, before and after

Setup — a lookup role that is not `postgres`, its credential in a mounted `userlist.txt`, and a client absent from that file:

```sh
docker network create demo

docker run -d --name pg --network demo \
    -e POSTGRES_PASSWORD=s3cret -e POSTGRES_DB=appdb \
    -e POSTGRES_INITDB_ARGS=--auth-host=md5 \
    postgres:17-alpine

docker exec pg psql -U postgres -tAX -c "set password_encryption='md5';
    create role lookup login superuser password 'lookuppw';
    create role other login password 'otherpw'"

printf '"lookup" "md5%s"\n' "$(printf 'lookuppwlookup' | md5sum | cut -d' ' -f1)" > userlist.txt
```

Before — `AUTH_USER=lookup` is set, and ignored:

```console
$ docker run -d --name old --network demo \
    -v "$PWD/userlist.txt:/etc/pgbouncer/userlist.txt:ro" \
    -e DB_HOST=pg -e DB_NAME=appdb -e AUTH_USER=lookup -e LISTEN_PORT=6432 \
    edoburu/pgbouncer:latest

$ docker exec -e PGPASSWORD=otherpw old \
    psql "postgres://other@127.0.0.1:6432/appdb" -tAX -c "select current_user"
psql: error: FATAL:  password authentication failed for user "postgres"
```

After — same everything, image built from this branch:

```console
$ docker build -t pgbouncer:fix .
$ docker run -d --name new --network demo \
    -v "$PWD/userlist.txt:/etc/pgbouncer/userlist.txt:ro" \
    -e DB_HOST=pg -e DB_NAME=appdb -e AUTH_USER=lookup -e LISTEN_PORT=6432 \
    pgbouncer:fix

$ docker exec -e PGPASSWORD=otherpw new \
    psql "postgres://other@127.0.0.1:6432/appdb" -tAX -c "select current_user"
other
```

- The rendered entries differ by one value: `auth_user=postgres` before, `auth_user=lookup` after.
- The old error names `postgres` — a role nothing in that configuration mentions — because the entry claimed an `auth_user` whose password was never written anywhere.

### What does not change

`DB_USER` still takes precedence, so #56 keeps working and clients keep reaching the server under their own identity.

| `DB_USER` | `AUTH_USER` | rendered |
|---|---|---|
| — | — | `auth_user=postgres` (unchanged) |
| — | `lookupuser` | `auth_user=lookupuser` (was `postgres`) |
| `appuser` | — | `auth_user=appuser` (unchanged) |
| `appuser` | `lookupuser` | `auth_user=appuser` (unchanged) |

- Checked against the built image, not reasoned about.
- Only the second row moves, and it is the row that could not work before: the entry named a user with no credential.

### What I left alone

- With neither variable set the entry still says `auth_user=postgres`.
  - A container with no `postgres` credential keeps answering unknown users with `password authentication failed for user "postgres"`.
  - Dropping that fallback reads better, but takes `auth_query` away from anyone mounting an `AUTH_FILE` holding a `postgres` credential with no `DB_*` set.
  - Happy to include it if you would rather have the clean default — it is one more `:-` removed.
- Measurements on what the fallback costs, including a server-side login attempt per rejected client, are in #134.

### Tests

I would rather this waited for #133 and merged after it.

- This change is one substitution in a `printf`; what deserves proving is that the other three combinations still render exactly as today.
- That is what a golden-file suite is for, and #133 adds one.
- Once it is in, I will add here:
  - a case per combination, so the table above becomes files in the repo rather than a claim in a description
  - a `# boot: yes` case, since a rendered `auth_user` is only worth anything if pgbouncer accepts the file
  - a live assertion mirroring the reproduction above
- Happy to merge as-is if you prefer not to couple the two, and to follow with the cases separately.

### Documentation

The README paragraph on `AUTH_USER` gains a sentence stating the precedence, since it previously described a variable with no effect on generated configs.

[Assisted-by](https://docs.kernel.org/process/coding-assistants.html#attribution): Claude:claude-opus-5[1m]